### PR TITLE
MultiPage Export

### DIFF
--- a/DokuWiki MultiPage Export.js
+++ b/DokuWiki MultiPage Export.js
@@ -88,8 +88,8 @@ function doExport() {
 
 
         // Begin the Output
-        Zotero.write("$==" + item.key + "==$\r"); //Used to split export into multiple files.
-	Zotero.write("======" + item.title + "======\r");
+        Zotero.write("$==" + item.key + "==$\n"); //Used to split export into multiple files.
+	Zotero.write("======" + item.title + "======\n");
         Zotero.write("**" + type + "**"); // low-key bold
         // Add a DokuWiki footnote citation
         Zotero.write("  ((" + mem.get() + " (" + memdate.get() + "), " + item.title + ", ");
@@ -102,18 +102,18 @@ function doExport() {
         else {
             Zotero.write("[[http://scholar.google.com/scholar?q=" + item.DOI + "]]");
         }
-        Zotero.write("))\r\r");
+        Zotero.write("))\n\n");
         // End of footnote citation
 
         // Write the Abstract
         if (item.abstractNote != "") {
-		Zotero.write(item.abstractNote + "\r");
-        	Zotero.write("\r----\r");
+		Zotero.write(item.abstractNote + "\n");
+        	Zotero.write("\n----\n");
 	}
 
         // List the zoteroID 
-        Zotero.write(" z-ref: [[zotero://select/items/0_"+item.key+ "|" + item.key.toLowerCase() + "]]\r\r");
-	Zotero.write("[[zotero:"+item.key+":notes | Notes]]\r\r");
+        Zotero.write(" z-ref: [[zotero://select/items/0_"+item.key+ "|" + item.key.toLowerCase() + "]]\n\n");
+	Zotero.write("[[zotero:"+item.key+":notes | Notes]]\n\n");
 
         // Write tags- needs Tag plugin
         if(item.tags && item.tags.length) {
@@ -127,14 +127,14 @@ function doExport() {
 
 	// Write notes
 	if(item.notes && item.notes.length) {
-		Zotero.write("\r=== Highlights ===\r");
+		Zotero.write("\n=== Highlights ===\n");
 		for (var i in item.notes){
 			Zotero.write("<HTML>");
 			Zotero.write(item.notes[i].note);
-			Zotero.write("</HTML>\r\r");
+			Zotero.write("</HTML>\n\n");
 		}
 	}
 
-	Zotero.write("\r\r");
+	Zotero.write("\n\n");
 	}
 }

--- a/DokuWiki MultiPage Export.js
+++ b/DokuWiki MultiPage Export.js
@@ -1,0 +1,140 @@
+{
+	"translatorID": "0295ad17-43d1-4619-9a67-bd751c2d345b9",
+	"label": "DokuWiki MultiPage Export",
+	"creator": "Jim Davis & Miguel A. Arroyo",
+	"target": "txt",
+	"minVersion": "3.0",
+	"maxVersion": "",
+	"priority": 100,
+	"displayOptions": {
+		"exportCharset": "UTF-8"
+	},
+	"inRepository": false,
+	"translatorType": 2,
+	"browserSupport": "",
+	"lastUpdated": "2016-03-17 11:15:08"
+}
+
+var zotero2MyMap = {
+	"book": "Book",
+	"bookSection": "Book Section",
+	"journalArticle": "Journal Article",
+	"magazineArticle": "Magazine Article",
+	"newspaperArticle": "Newspaper Article",
+	"thesis": "Thesis",
+	"letter": "Letter",
+	"manuscript": "Manuscript",
+	"interview": "Interview",
+	"film": "movie",
+	"artwork": "Artwork",
+	"webpage": "Web Page",
+	"conferencePaper": "Conference Paper",
+	"report": "Report",
+	"bill": "Bill",
+	"case": "Case",
+	"hearing": "Hearing",
+	"patent": "Patent",
+	"statute": "Statute",
+	"email": "e-mail",
+	"map": "Map",
+	"blogPost": "Blog Post",
+	"instantMessage": "Instant Message",
+	"forumPost": "Forum Post",
+	"audioRecording": "Audio",
+	"presentation": "Presentation",
+	"videoRecording": "Video",
+	"tvBroadcast": "TV Broadcast",
+	"radioBroadcast": "Radio Broadcast",
+	"podcast": "Podcast",
+	"computerProgram": "Software",
+	"document": "Document",
+	"encyclopediaArticle": "Encylopedia Article",
+	"dictionaryEntry": "Dictionary Entry"
+};
+
+// legal types are weird
+var LEGAL_TYPES = ["bill","case","gazette","hearing","patent","regulation","statute","treaty"];
+var Mem = function (item) {
+    var lst = [];
+    var isLegal = isLegal = (LEGAL_TYPES.indexOf(item.itemType)>-1);
+    this.set = function (str, punc, slug) { if (!punc) {punc=""}; if (str) {lst.push((str + punc))} else if (!isLegal) {lst.push(slug)}};
+    this.setlaw = function (str, punc) { if (!punc) {punc=""}; if (str && isLegal) {lst.push(str + punc)}};
+    this.get = function () { return lst.join(" ") };
+}
+
+
+function doExport() {
+    var item;
+    while (item = Zotero.nextItem()) {
+        var mem = new Mem(item);
+        var memdate = new Mem(item);
+		var type = zotero2MyMap[item.itemType];
+        var library_id = item.libraryID ? item.libraryID : 0;
+        var date = Zotero.Utilities.strToDate(item.date);
+        // Format the accessDate (remove time)
+		var accessYMD = item.accessDate.replace(/\s*\d+:\d+:\d+/, "");
+        var dateS = (date.year) ? date.year : item.date;
+        memdate.set(dateS,"","no date");
+
+        // Check for author, use anon. if needed, and use 2 Authors max
+        if (item.creators.length >0){
+            mem.set(item.creators[0].lastName);
+            if (item.creators.length > 2) mem.set(", et al.");
+            else if (item.creators.length == 2) mem.set("& " + item.creators[1].lastName);
+        }
+        else {
+            mem.set(false, "","anon.");
+        }
+
+
+        // Begin the Output
+        Zotero.write("$==" + item.key + "==$\r"); //Used to split export into multiple files.
+	Zotero.write("======" + item.title + "======\r");
+        Zotero.write("**" + type + "**"); // low-key bold
+        // Add a DokuWiki footnote citation
+        Zotero.write("  ((" + mem.get() + " (" + memdate.get() + "), " + item.title + ", ");
+
+        // Check for a url, if none then do a Google Scholar link on the DOI
+        if (item.url) {
+            Zotero.write("[[" + item.url + "]]");
+            Zotero.write(" accessed: " + accessYMD);
+        }
+        else {
+            Zotero.write("[[http://scholar.google.com/scholar?q=" + item.DOI + "]]");
+        }
+        Zotero.write("))\r\r");
+        // End of footnote citation
+
+        // Write the Abstract
+        if (item.abstractNote != "") {
+		Zotero.write(item.abstractNote + "\r");
+        	Zotero.write("\r----\r");
+	}
+
+        // List the zoteroID 
+        Zotero.write(" z-ref: [[zotero://select/items/0_"+item.key+ "|" + item.key.toLowerCase() + "]]\r\r");
+	Zotero.write("[[zotero:"+item.key+":notes | Notes]]\r\r");
+
+        // Write tags- needs Tag plugin
+        if(item.tags && item.tags.length) {
+            var tagString = "";
+			for(var i in item.tags) {
+			   var tag = item.tags[i];
+               tagString += tag.tag + " ";
+            }
+		    Zotero.write("{{tag>" + tagString + "}}");
+		}        
+
+	// Write notes
+	if(item.notes && item.notes.length) {
+		Zotero.write("\r=== Highlights ===\r");
+		for (var i in item.notes){
+			Zotero.write("<HTML>");
+			Zotero.write(item.notes[i].note);
+			Zotero.write("</HTML>\r\r");
+		}
+	}
+
+	Zotero.write("\r\r");
+	}
+}

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ zotero2dokuwiki
 zotero to DokuWiki export translators.
 Put the .js files into your zotero translators folder.
 
-The Page Creator generates a list in a DokuWiki page that is a title(s) with link(s) to a unique page name that matches the unique ID of your local zotero item.
+The Page List Creator generates a list in a DokuWiki page that is a title(s) with link(s) to a unique page name that matches the unique ID of your local zotero item.
 
-Once this list page is created and saved, switch zotero to use the Page Entry export, the click the DokuWiki list page link and it will look for the unique page name. 
+Once this list page is created and saved, switch zotero to use the MultiPage export. Export your library into a txt file. The txt file will contain all of your zotero entries in one. 
 
-Once you have created the page, copy the Page Entry output into the DokuWiki editor and save the page.
+Run the split_multipage_export.py script in order to split the file above and output to your DokuWiki data folder.
 
 Enjoy.

--- a/split_multipage_export.py
+++ b/split_multipage_export.py
@@ -1,0 +1,34 @@
+"""Split Multipage Export into individual txt files
+Usage:
+    split_multipage_export.py <export_filename> <output_dir>
+"""
+import re
+import os
+from docopt import docopt
+
+def split_multipage_export(filename, output_dir):
+    fp = open(filename, 'r')
+    data = fp.readlines()
+    zotero_key_pattern = re.compile('\$==(.*)==\$')
+    
+    zotero_key = None
+    output_file = None
+    
+    for line in data:
+        m = zotero_key_pattern.match(line)
+        if m:
+            zotero_key = m.group()
+            zotero_key = zotero_key.replace('$==','')
+            zotero_key = zotero_key.replace('==$','')
+            zotero_key = zotero_key.lower()
+            output_file = open(os.path.join(output_dir,zotero_key + '.txt'),'w')
+        else:
+            output_file.write(line)
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__)
+
+    export_filename = arguments['<export_filename>']
+    output_dir = arguments['<output_dir>']
+
+    split_multipage_export(export_filename, output_dir)


### PR DESCRIPTION
Hi,

I've found your export translators to be very useful. I'm using DokuWiki and Zotero to manage my current research and have implemented an additional export to extract the entire library. Then with the use of a python script I split into individual txts based on the zotero key which can then be copied to the DokuWiki data folder. If this sounds like a reasonable addition feel free to merge it in.

Cheers!
